### PR TITLE
Fix an edge case with the NoEmptyLinesSniff on Closing Braces

### DIFF
--- a/src/LearnDash/Sniffs/Braces/NoEmptyLinesSniff.php
+++ b/src/LearnDash/Sniffs/Braces/NoEmptyLinesSniff.php
@@ -137,7 +137,14 @@ class NoEmptyLinesSniff implements Sniff {
 				$phpcs_file->fixer->beginChangeset();
 
 				for ( $i = ( $previous + 1 ); $i < $closer; $i++ ) {
-					if ( $tokens[ $i ]['line'] !== $tokens[ $previous ]['line'] ) {
+					if (
+						$tokens[ $i ]['line'] !== $tokens[ $previous ]['line']
+						// Accounts for an edge case where the token immediately before the closing brace is a Comment with a line break at the end of it.
+						&& (
+							$tokens[ $i ]['line'] !== $tokens[ $previous ]['line'] + 1
+							|| $tokens[ $previous ]['type'] !== 'T_COMMENT'
+						)
+					) {
 						continue;
 					}
 


### PR DESCRIPTION
Code like the following would previously prevent scanning for issues from completing properly.

```php
if ( isset( $request['email_user_enabled'] ) ) {
	$user_email_notification = $request['email_user_enabled'];
	$user_email_notification = filter_var( $request['email_user_enabled'], FILTER_VALIDATE_BOOLEAN );
	if ( $user_email_notification ) {
		$user_email_notification = (int) 1;
	} else {
		$user_email_notification = (int) 0;
	}
	$data['user_email_notification'] = $user_email_notification;// user email eg 1 notification (USER).

}
```

The trailing line after the end of the comment wasn't being recognized properly as the line number of the Token doesn't match since the line break itself is a part of the Comment Token rather than being its own Token like it normally would be.

This change accounts for that while ensuring it should not be able to result in false positives in other scenarios.

There may be other potential, similar, issues that could arise. But this is the most likely to occur I believe.

I was not able to cause a similar issue with the opening brace, so this should only be a problem with closing braces.