### PR TITLE
Add sprintf/printf specifier format sniff

### DIFF
--- a/src/LearnDash/Sniffs/PHP/SprintfFormatSniff.php
+++ b/src/LearnDash/Sniffs/PHP/SprintfFormatSniff.php
@@ -6,6 +6,8 @@
  * @package StellarWP/learndash-php-sniffs
  */
 
+namespace StellarWP\PHP_Sniffs\LearnDash\Sniffs\PHP;
+
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
 
@@ -17,9 +19,9 @@ class SprintfFormatSniff implements Sniff
     /**
      * Returns the tokens that this sniff is interested in.
      *
-     * @return array
+     * @return array<string>
      */
-    public function register()
+    public function register(): array
     {
         return [T_STRING];
     }
@@ -27,29 +29,29 @@ class SprintfFormatSniff implements Sniff
     /**
      * Processes this sniff, when one of its tokens is encountered.
      *
-     * @param File $phpcsFile The file being scanned.
-     * @param int  $stackPtr  The position of the current token in the stack.
+     * @param File $file       The file being scanned.
+     * @param int  $stackIndex The position of the current token in the stack.
      *
      * @return void
      */
-    public function process(File $phpcsFile, $stackPtr)
+    public function process(File $file, $stackIndex): void
     {
-        $tokens = $phpcsFile->getTokens();
-        $token  = $tokens[$stackPtr];
+        $tokens = $file->getTokens();
+        $token  = $tokens[$stackIndex];
 
         // Only check sprintf and printf calls.
-        if (!in_array(strtolower($token['content']), ['sprintf', 'printf'], true)) {
+        if (! in_array(strtolower($token['content']), ['sprintf', 'printf'], true)) {
             return;
         }
 
         // Find the opening parenthesis.
-        $openPtr = $phpcsFile->findNext(T_OPEN_PARENTHESIS, $stackPtr + 1);
+        $openPtr = $file->findNext(T_OPEN_PARENTHESIS, $stackIndex + 1);
         if (!$openPtr) {
             return;
         }
 
         // Find the first argument (should be a string literal).
-        $firstArgPtr = $phpcsFile->findNext([T_CONSTANT_ENCAPSED_STRING, T_DOUBLE_QUOTED_STRING], $openPtr + 1, null, false, null, true);
+        $firstArgPtr = $file->findNext([T_CONSTANT_ENCAPSED_STRING, T_DOUBLE_QUOTED_STRING], $openPtr + 1, null, false, null, true);
         if (!$firstArgPtr) {
             return;
         }
@@ -70,7 +72,7 @@ class SprintfFormatSniff implements Sniff
             $specifier = $match[0];
             if (!in_array($specifier, $allowed, true)) {
                 $fullMatch = $matches[0][$idx][0];
-                $phpcsFile->addError(
+                $file->addError(
                     'Invalid sprintf/printf format specifier: "%s"',
                     $firstArgPtr,
                     'InvalidSprintfSpecifier',

--- a/src/LearnDash/Sniffs/PHP/SprintfFormatSniff.php
+++ b/src/LearnDash/Sniffs/PHP/SprintfFormatSniff.php
@@ -3,7 +3,7 @@
  * Custom PHPCS sniff to check for valid sprintf format specifiers.
  *
  * @author LearnDash
- * @license GPL-2.0-or-later
+ * @package StellarWP/learndash-php-sniffs
  */
 
 use PHP_CodeSniffer\Files\File;

--- a/src/LearnDash/Sniffs/PHP/SprintfFormatSniff.php
+++ b/src/LearnDash/Sniffs/PHP/SprintfFormatSniff.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Custom PHPCS sniff to check for valid sprintf format specifiers.
+ *
+ * @author LearnDash
+ * @license GPL-2.0-or-later
+ */
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+/**
+ * Checks for valid sprintf format specifiers in PHP code.
+ */
+class SprintfFormatSniff implements Sniff
+{
+    /**
+     * Returns the tokens that this sniff is interested in.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return [T_STRING];
+    }
+
+    /**
+     * Processes this sniff, when one of its tokens is encountered.
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  The position of the current token in the stack.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+        $token  = $tokens[$stackPtr];
+
+        // Only check sprintf and printf calls.
+        if (!in_array(strtolower($token['content']), ['sprintf', 'printf'], true)) {
+            return;
+        }
+
+        // Find the opening parenthesis.
+        $openPtr = $phpcsFile->findNext(T_OPEN_PARENTHESIS, $stackPtr + 1);
+        if (!$openPtr) {
+            return;
+        }
+
+        // Find the first argument (should be a string literal).
+        $firstArgPtr = $phpcsFile->findNext([T_CONSTANT_ENCAPSED_STRING, T_DOUBLE_QUOTED_STRING], $openPtr + 1, null, false, null, true);
+        if (!$firstArgPtr) {
+            return;
+        }
+
+        $formatString = $tokens[$firstArgPtr]['content'];
+        $formatString = $this->stripQuotes($formatString);
+
+        // Regex to match all sprintf/printf format specifiers (including invalid ones).
+        $pattern_all = '/%(?:\d+\$)?[+-]?(?:\d+)?(?:\.\d+)?([a-zA-Z])/';
+        preg_match_all($pattern_all, $formatString, $matches, PREG_OFFSET_CAPTURE);
+
+        // Allowed conversion characters for sprintf/printf.
+        $allowed = [
+            'b', 'c', 'd', 'e', 'E', 'f', 'F', 'g', 'G', 'o', 's', 'u', 'x', 'X'
+        ];
+
+        foreach ($matches[1] as $idx => $match) {
+            $specifier = $match[0];
+            if (!in_array($specifier, $allowed, true)) {
+                $fullMatch = $matches[0][$idx][0];
+                $phpcsFile->addError(
+                    'Invalid sprintf/printf format specifier: "%s"',
+                    $firstArgPtr,
+                    'InvalidSprintfSpecifier',
+                    [$fullMatch]
+                );
+            }
+        }
+    }
+
+    /**
+     * Strips quotes from a PHP string literal.
+     *
+     * @param string $str
+     *
+     * @return string
+     */
+    protected function stripQuotes($str)
+    {
+        if (strlen($str) > 1 && ($str[0] === '"' || $str[0] === "'")) {
+            return substr($str, 1, -1);
+        }
+        return $str;
+    }
+}


### PR DESCRIPTION
I got this issue when working in LD core from a typo:

```
Fatal error: Uncaught Error: Unknown format specifier 'S'
```

because I accidentally used `%S` instead of `%s` in a `sprintf` call.

This custom sniff will catch that. It also supports the placement format like `%1$s`, `%2$d`, etc.

Ideally this sniff is added to a global custom PHP sniffs in PHPCS but I think it'd be too long to wait this to get approved and merged in phpcs repo.

Usage in the custom ruleset:

```
<rule ref="LearnDash.PHP.SprintfFormat" />
```